### PR TITLE
Fix typo of __dealloc__ method.

### DIFF
--- a/pynvvl/_nvvl.pyx
+++ b/pynvvl/_nvvl.pyx
@@ -146,7 +146,7 @@ cdef class NVVLVideoLoader:
                 '\'error\', or \'none\', but {} was given.'.format(log_level))
         self.device_id = device_id
 
-    def __deaclloc__(self):
+    def __dealloc__(self):
         nvvl_destroy_video_loader(self.handle)
 
     def frame_count(self, filename):


### PR DESCRIPTION
This PR changes a method name `__deaclloc__` to `__dealloc__` in NVVLVideoLoader.